### PR TITLE
Add h2 to section only visible by screenreader: Section 3 - Quotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -349,3 +349,4 @@ MigrationBackup/
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
 .vscode/settings.json
+.vscode/numbered-bookmarks.json

--- a/css/style.css
+++ b/css/style.css
@@ -49,11 +49,13 @@ p {
   min-width: 12ch;
 }
 
+/* // */
 /* * */
 /* * utility classes */
 /* * */
+/* // */
 
-/* sizing */
+/* * sizing */
 .container {
   max-width: 62.5em;
   margin: 0 auto;
@@ -68,6 +70,7 @@ p {
   margin-top: var(--flow-spacer, 0.75em);
 }
 
+/* * flexing */
 /* flex row - flex-column */
 .flex-row {
   display: flex;
@@ -77,7 +80,27 @@ p {
   display: flex;
   flex-direction: column;
 }
-/* color */
+
+/* * accessibility */
+
+/* text and elements only for screen readers - hides from view */
+.screenreader-accessibility-text {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  height: 1px;
+  width: 1px;
+}
+
+.screenreader-accessibility-text:focus {
+  display: inline-block;
+  position: static;
+  height: auto;
+  margin: auto;
+  width: auto;
+}
+
+/* * color */
 .bg-dark {
   background-color: var(--clr-dark-900);
 }

--- a/index.html
+++ b/index.html
@@ -80,6 +80,9 @@
       <section class="home-section">
         <div class="container flow">
           <div class="quote">
+            <h2 class="screenreader-accessibility-text">
+              Quote by Thor, God of Thunder
+            </h2>
             <blockquote>
               Lorem ipsum dolor, sit amet consectetur adipisicing elit. Eos sed
               quasi aperiam earum doloremque at error voluptate, incidunt


### PR DESCRIPTION
## **Why?**
- Markup validator required a section to have a h2-h6 heading and the
quote section didn't have one.

## **What?**
- Add class `.screenreader-accessibility-text` to hide the `h2`
from plain view.
- Add pseudo-class `.screenreader-accessibility-text:focus` to show the
text `h2` when focussed.
